### PR TITLE
Linux compat /  use int32 for some mnemonics

### DIFF
--- a/source/Reloaded.Hooks/Tools/Utilities.cs
+++ b/source/Reloaded.Hooks/Tools/Utilities.cs
@@ -199,7 +199,7 @@ namespace Reloaded.Hooks.Tools
         /// <param name="is64bit">True to generate x64 code, else false (x86 code).</param>
         public static string GetAbsoluteJumpMnemonics(nuint target, bool is64bit)
         {
-            var buffer = FindOrCreateBufferInRange(IntPtr.Size, 1, UInt32.MaxValue);
+            var buffer = FindOrCreateBufferInRange(IntPtr.Size, 1, Int32.MaxValue);
             nuint functionPointer = buffer.Add(ref target);
 
             if (is64bit) return "jmp qword [qword " + functionPointer + "]";
@@ -213,7 +213,7 @@ namespace Reloaded.Hooks.Tools
         /// <param name="is64bit">True to generate x64 code, else false (x86 code).</param>
         public static string GetAbsoluteCallMnemonics(nuint target, bool is64bit)
         {
-            var buffer = FindOrCreateBufferInRange(IntPtr.Size, 1, UInt32.MaxValue);
+            var buffer = FindOrCreateBufferInRange(IntPtr.Size, 1, Int32.MaxValue);
             nuint functionPointer = buffer.Add(ref target);
 
             if (is64bit) return "call qword [qword " + functionPointer + "]";


### PR DESCRIPTION
After trialing the changes from https://github.com/xivdev/Penumbra/issues/484#issuecomment-2849282031 locally for a week I can confirm these changes stop the crashes seen on Linux when not using Wine 8. This PR unblocks the official launcher upgrading to Wine 10